### PR TITLE
History decrease for non beta cutoff moves

### DIFF
--- a/src/search/history.h
+++ b/src/search/history.h
@@ -30,6 +30,10 @@ namespace search {
             butterfly[move.get_from()][move.get_to()] += 100 * depth;
         }
 
+        void decrease_history(core::Move move, Depth depth) {
+            butterfly[move.get_from()][move.get_to()] -= 100 * depth;
+        }
+
         void clear() {
             for (int i = 0; i < MAX_PLY + 2; i++) {
                 killer_moves[i][0] = killer_moves[i][1] = core::NULL_MOVE;

--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -245,6 +245,7 @@ namespace search {
                 return in_check ? mate_ply : 0;
             }
 
+            std::vector<core::Move> quiet_moves;
             bool skip_quiets = false;
             int made_moves = 0;
             while (!move_list.empty()) {
@@ -286,6 +287,9 @@ namespace search {
 
                     if (move.is_quiet()) {
                         history.add_cutoff(move, depth, ss->ply);
+                        for (const core::Move &m : quiet_moves) {
+                            history.decrease_history(m, depth);
+                        }
                     }
 
                     shared.tt.save(board.get_hash(), depth, beta, TT_BETA, move);
@@ -312,6 +316,7 @@ namespace search {
                 }
 
                 made_moves++;
+                if (move.is_quiet()) quiet_moves.emplace_back(move);
             }
 
             shared.tt.save(board.get_hash(), depth, best_score, flag, best_move);


### PR DESCRIPTION
STC:
```
ELO   | 23.14 +- 10.92 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2496 W: 881 L: 715 D: 900
```
LTC:
```
ELO   | 24.24 +- 10.87 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2240 W: 715 L: 559 D: 966
```

Bench: 5056595