### PR TITLE
Bonus for rook on open file

### DIFF
--- a/src/network/eval.h
+++ b/src/network/eval.h
@@ -95,6 +95,14 @@ namespace nn {
                         piece_score += pawn_table[pov_sq];
                     } else if (pt == BISHOP) {
                         piece_score += bishop_table[pov_sq];
+                    } else if (pt == ROOK) {
+                        core::Bitboard pawns = core::masks_file[sq] & board.pieces<PAWN>();
+                        int pawn_count = pawns.pop_count();
+                        if (pawn_count == 0) {
+                            piece_score += 15;
+                        } else if (pawn_count == 1) {
+                            piece_score += 5;
+                        }
                     }
 
                     // Mobility


### PR DESCRIPTION
STC:
```
ELO   | 40.47 +- 14.97 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1440 W: 577 L: 410 D: 453
```

LTC:
```
ELO   | 58.32 +- 17.62 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 896 W: 337 L: 188 D: 371
```

Bench: 5197427