### PR TITLE
Bonus for bishop pair

### DIFF
--- a/src/network/eval.h
+++ b/src/network/eval.h
@@ -89,6 +89,9 @@ namespace nn {
             Score piece_score = 0;
             for (PieceType pt : {PAWN, KNIGHT, BISHOP, ROOK, QUEEN}) {
                 core::Bitboard bb = board.pieces(color, pt);
+
+                if (pt == BISHOP && bb.pop_count() == 2) piece_score += 50;
+
                 while (bb) {
                     phase += PIECE_TO_PHASE_INT[pt];
                     Square sq = bb.pop_lsb();


### PR DESCRIPTION
STC:
```
ELO   | 12.68 +- 7.76 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5128 W: 1802 L: 1615 D: 1711
```
LTC:
```
ELO   | 11.34 +- 7.16 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5608 W: 1832 L: 1649 D: 2127
```

Bench: 4866151