### PR TITLE
Passed pawns

### DIFF
--- a/src/core/masks.h
+++ b/src/core/masks.h
@@ -24,6 +24,7 @@ namespace core {
     extern Bitboard masks_adjacent_north[64];
     extern Bitboard masks_adjacent_south[64];
     extern Bitboard masks_pawn[64][2];
+    extern Bitboard masks_passed_pawn[64][2];
     extern Bitboard masks_knight[64];
     extern Bitboard masks_king[64];
     extern Bitboard masks_file[64];
@@ -81,6 +82,18 @@ namespace core {
                                        (file != 7 ? slide<SOUTH>(sq + EAST) : 0);
             masks_adjacent_file[sq] =
                     ~masks_file[sq] & (masks_adjacent_north[sq] | masks_adjacent_south[sq] | step<WEST>(sq) | step<EAST>(sq));
+
+            masks_passed_pawn[sq][WHITE] = slide<NORTH>(sq);
+            masks_passed_pawn[sq][BLACK] = slide<SOUTH>(sq);
+
+            if (!FILE_A.get(sq)) {
+                masks_passed_pawn[sq][WHITE] |= slide<NORTH>(sq + WEST);
+                masks_passed_pawn[sq][BLACK] |= slide<SOUTH>(sq + WEST);
+            }
+            if (!FILE_H.get(sq)) {
+                masks_passed_pawn[sq][WHITE] |= slide<NORTH>(sq + EAST);
+                masks_passed_pawn[sq][BLACK] |= slide<SOUTH>(sq + EAST);
+            }
 
             // Calculates the common ray and the line type of the shortest path between sq and sq2.
             for (Square sq2 = A1; sq2 < 64; sq2 += 1) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ namespace nn {
 
 namespace core {
     // Declarations
-    Bitboard masks_bit[64], masks_adjacent_file[64], masks_adjacent_north[64], masks_adjacent_south[64], masks_pawn[64][2],
+    Bitboard masks_bit[64], masks_adjacent_file[64], masks_adjacent_north[64], masks_adjacent_south[64], masks_pawn[64][2], masks_passed_pawn[64][2],
             masks_knight[64], masks_king[64], masks_file[64], masks_rank[64], masks_rook[64], masks_diagonal[64],
             masks_anti_diagonal[64], masks_bishop[64], masks_common_ray[64][64];
     LineType line_type[64][64];

--- a/src/network/eval.h
+++ b/src/network/eval.h
@@ -87,6 +87,7 @@ namespace nn {
 
         for (Color color : {WHITE, BLACK}) {
             Score piece_score = 0;
+            core::Bitboard enemy_pawns = board.pieces<PAWN>(color_enemy(color));
             for (PieceType pt : {PAWN, KNIGHT, BISHOP, ROOK, QUEEN}) {
                 core::Bitboard bb = board.pieces(color, pt);
 
@@ -100,6 +101,10 @@ namespace nn {
                     // PST
                     if (pt == PAWN) {
                         piece_score += pawn_table[pov_sq];
+
+                        core::Bitboard passed = core::masks_passed_pawn[sq][color];
+                        if (!(passed & enemy_pawns))
+                            piece_score += 50;
                     } else if (pt == BISHOP) {
                         piece_score += bishop_table[pov_sq];
                     } else if (pt == ROOK) {

--- a/src/network/eval.h
+++ b/src/network/eval.h
@@ -104,7 +104,7 @@ namespace nn {
 
                         core::Bitboard passed = core::masks_passed_pawn[sq][color];
                         if (!(passed & enemy_pawns))
-                            piece_score += 50;
+                            piece_score += 20;
                     } else if (pt == BISHOP) {
                         piece_score += bishop_table[pov_sq];
                     } else if (pt == ROOK) {


### PR DESCRIPTION
STC:
```
ELO   | 6.61 +- 5.02 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 12136 W: 4129 L: 3898 D: 4109
```
LTC:
```
ELO   | 10.36 +- 6.79 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6304 W: 2070 L: 1882 D: 2352
```

Bench: 4984753