### PR TITLE
TT cutoffs

### DIFF
--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -209,6 +209,11 @@ namespace search {
             TTFlag flag = TT_ALPHA;
             core::Move hash_move = entry ? entry->hash_move : core::NULL_MOVE;
 
+            if (entry && non_pv_node && entry->depth >= depth && board.get_move50() < 90 &&
+                (entry->flag == TT_EXACT || (entry->flag == TT_ALPHA && entry->eval <= alpha) || (entry->flag == TT_BETA && entry->eval >= beta))) {
+                return entry->eval;
+            }
+
             if (depth <= 0)
                 return qsearch<node_type>(alpha, beta);
 

--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -310,7 +310,6 @@ namespace search {
                 if (score > best_score) {
                     best_score = score;
                     best_move = move;
-                    flag = TT_EXACT;
 
                     if (id == 0) {
                         pv_array[ss->ply][ss->ply] = move;
@@ -322,6 +321,7 @@ namespace search {
 
 
                     if (score > alpha) {
+                        flag = TT_EXACT;
                         alpha = score;
                     }
                 }


### PR DESCRIPTION
STC:
```
ELO   | 171.60 +- 34.95 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 328 W: 190 L: 40 D: 98
```
LTC:
```
ELO   | 247.69 +- 45.96 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 240 W: 162 L: 15 D: 63
```
Bench: 3177113