### PR TITLE
King safety 2

### DIFF
--- a/src/network/eval.h
+++ b/src/network/eval.h
@@ -101,6 +101,7 @@ namespace nn {
 
         Score king_safety = 0;
         king_safety += 15 * pawn_shield_1.pop_count();
+        king_safety += 5 * pawn_shield_2.pop_count();
 
         attacked -= 2 * pawn_shield_1.pop_count();
         attacked -= 1 * pawn_shield_2.pop_count();


### PR DESCRIPTION
King safety vs master

STC:
```
ELO   | 89.31 +- 23.10 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 648 W: 307 L: 144 D: 197
```
LTC:
```
ELO   | 123.85 +- 28.52 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 456 W: 239 L: 83 D: 134
```

King safety 2 vs King safety

STC:
```
ELO   | 5.67 +- 4.41 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 14152 W: 4318 L: 4087 D: 5747
```

Bench: 3078285