### PR TITLE
Do not generate moves for prunable nodes in qsearch

### DIFF
--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -348,14 +348,14 @@ namespace search {
                 return UNKNOWN_SCORE;
             }
 
-            MoveList<true> move_list(board, core::NULL_MOVE, history, 0);
-
             Score static_eval = nnue.evaluate(board.get_stm());
 
             if (static_eval >= beta)
                 return beta;
             if (static_eval > alpha)
                 alpha = static_eval;
+
+            MoveList<true> move_list(board, core::NULL_MOVE, history, 0);
 
             while (!move_list.empty()) {
                 core::Move move = move_list.next_move();


### PR DESCRIPTION
STC:
```
ELO   | 31.63 +- 12.65 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1696 W: 570 L: 416 D: 710
```

Bench: 4827524