### PR TITLE
SEE pruning in qsearch

### DIFF
--- a/src/search/move_list.h
+++ b/src/search/move_list.h
@@ -19,6 +19,7 @@
 
 #include "../core/movegen.h"
 #include "history.h"
+#include "see.h"
 
 namespace search {
     template<bool captures_only>

--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -360,6 +360,8 @@ namespace search {
             while (!move_list.empty()) {
                 core::Move move = move_list.next_move();
 
+                if (alpha > -WORST_MATE && !see(board, move, 0)) continue;
+
                 shared.node_count++;
                 board.make_move(move, &nnue);
                 Score score = -qsearch<node_type>(-beta, -alpha);

--- a/src/search/see.h
+++ b/src/search/see.h
@@ -61,7 +61,7 @@ namespace search {
             stm = color_enemy(stm);
 
             if (value >= 0) {
-                if (type == KING && (attackers & board.pieces(stm))) {
+                if (type == KING && (attackers & board.sides(stm))) {
                     stm = color_enemy(stm);
                 }
                 break;


### PR DESCRIPTION
STC:
```
ELO   | 17.24 +- 9.10 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3408 W: 1120 L: 951 D: 1337
```

LTC:
```
ELO   | 3.51 +- 2.81 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 31944 W: 8869 L: 8546 D: 14529
```

Bench: 2525875