### PR TITLE
Disable IIR in pv nodes

### DIFF
--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -226,7 +226,7 @@ namespace search {
             if (root_node || in_check)
                 goto search_moves;
 
-            if (!entry && depth >= 5)
+            if (!entry && non_pv_node && depth >= 4)
                 depth--;
 
             if (depth <= 3 && static_eval + 150 * depth <= alpha) {


### PR DESCRIPTION
STC:
```
ELO   | 9.17 +- 6.13 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6936 W: 2041 L: 1858 D: 3037
```

LTC:
```
ELO   | 6.90 +- 4.97 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 9872 W: 2698 L: 2502 D: 4672
```


Bench: 2160633