### PR TITLE
Improve rfp & smaller aspiration window

### DIFF
--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -125,7 +125,7 @@ namespace search {
 
         Score aspiration_window(Depth depth, Score prev_score) {
 
-            static constexpr Score DELTA = 30;
+            static constexpr Score DELTA = 20;
             static constexpr Score BOUND = 1500;
 
             Score delta = DELTA;

--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -222,6 +222,7 @@ namespace search {
                 return qsearch<node_type>(alpha, beta);
 
             Score static_eval = ss->eval = nnue.evaluate(board.get_stm());
+            bool improving = ss->ply >= 2 && ss->eval >= (ss-2)->eval;
 
             if (root_node || in_check)
                 goto search_moves;
@@ -235,7 +236,7 @@ namespace search {
                     return score;
             }
 
-            if (non_pv_node && depth <= 6 && static_eval - depth * 100 >= beta && std::abs(beta) < WORST_MATE)
+            if (non_pv_node && depth <= 6 && static_eval - (depth - improving) * 70 >= beta && std::abs(beta) < WORST_MATE)
                 return static_eval;
 
             if (non_pv_node && depth >= 3 && static_eval >= beta && board.has_non_pawn()) {

--- a/src/utils/bench.h
+++ b/src/utils/bench.h
@@ -62,8 +62,7 @@ void run_bench() {
     sm.allocate_threads(1);
     sm.allocate_hash(32);
 
-    search::Limits limits;
-    limits.depth = 9;
+    search::Limits limits = search::create_depth_limit(11);
 
     int64_t nodes = 0;
     int64_t start_time = now();


### PR DESCRIPTION
### Smaller aspiration window

STC:
```
ELO   | 2.85 +- 2.07 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 61488 W: 17782 L: 17278 D: 26428
```

-------------------------------------------------------------------------

### Improve RFP

STC:
```
ELO   | 41.98 +- 14.73 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1264 W: 445 L: 293 D: 526
```

LTC:
```
ELO   | 39.77 +- 14.51 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1360 W: 492 L: 337 D: 531
```
