### PR TITLE
Cleanup

### DIFF
--- a/src/core/attacks.h
+++ b/src/core/attacks.h
@@ -22,17 +22,17 @@
 
 namespace core {
 
-    [[nodiscard]] inline Bitboard attacks_rook(Square square, Bitboard occ) {
+    [[nodiscard]] Bitboard attacks_rook(Square square, Bitboard occ) {
         const Magic &m = magic_rook[square];
         return m.ptr[get_magic_index(m, occ)];
     }
 
-    [[nodiscard]] inline Bitboard attacks_bishop(Square square, Bitboard occ) {
+    [[nodiscard]] Bitboard attacks_bishop(Square square, Bitboard occ) {
         const Magic &m = magic_bishop[square];
         return m.ptr[get_magic_index(m, occ)];
     }
 
-    [[nodiscard]] inline Bitboard attacks_queen(Square square, Bitboard occ) {
+    [[nodiscard]] Bitboard attacks_queen(Square square, Bitboard occ) {
         return attacks_rook(square, occ) | attacks_bishop(square, occ);
     }
 
@@ -55,7 +55,7 @@ namespace core {
         }
     }
 
-    [[nodiscard]] inline Bitboard attacks_piece(PieceType pt, Square square, Bitboard occupied) {
+    [[nodiscard]] Bitboard attacks_piece(PieceType pt, Square square, Bitboard occupied) {
         assert((pt != PAWN) && (pt != PIECE_EMPTY));
         switch (pt) {
             case KNIGHT:
@@ -74,7 +74,7 @@ namespace core {
     }
 
     template<Color color>
-    [[nodiscard]] inline Bitboard attacks_piece(PieceType pt, Square square, Bitboard occupied) {
+    [[nodiscard]] Bitboard attacks_piece(PieceType pt, Square square, Bitboard occupied) {
         assert((pt != PAWN) && (pt != PIECE_EMPTY));
         switch (pt) {
             case PAWN:

--- a/src/core/bitboard.h
+++ b/src/core/bitboard.h
@@ -39,7 +39,7 @@ namespace core {
             bb = value;
         }
 
-        inline Bitboard(Square square);
+        Bitboard(Square square);
 
         constexpr Bitboard() = default;
 
@@ -64,17 +64,8 @@ namespace core {
         }
 
         // Returns the square with the lowest index, that is set to 1.
-        [[nodiscard]] inline Square lsb() const {
-
-#ifdef __GNUC__
-            return Square(__builtin_ctzll(bb));
-#elif defined(_MSC_VER)
-            unsigned long a;
-            _BitScanForward64(&a, bb);
-            return Square(a);
-#else
-#error "Unsupported compiler!"
-#endif
+        [[nodiscard]] Square lsb() const {
+            return Square(std::countr_zero(bb));
         }
 
         // Clears the square with the lowest index, that is set to 1.
@@ -193,7 +184,7 @@ namespace core {
 
     extern Bitboard masks_bit[64];
 
-    inline Bitboard::Bitboard(Square square) {
+    Bitboard::Bitboard(Square square) {
         bb = masks_bit[square].bb;
     }
 
@@ -252,7 +243,7 @@ namespace core {
         return result;
     }
 
-    [[nodiscard]] inline Bitboard slide(Direction direction, Square square) {
+    [[nodiscard]] Bitboard slide(Direction direction, Square square) {
         Bitboard result;
         Bitboard temp = {square};
         while (temp) {

--- a/src/core/board.h
+++ b/src/core/board.h
@@ -100,7 +100,7 @@ namespace core {
             return ~occupied();
         }
 
-        [[nodiscard]] inline bool is_draw() const {
+        [[nodiscard]] bool is_draw() const {
             if (get_move50() >= 100) return true;
             int cnt = 0;
             for (const BoardState &st : states) {
@@ -111,14 +111,14 @@ namespace core {
             return cnt >= 2;
         }
 
-        [[nodiscard]] inline bool is_check() const;
+        [[nodiscard]] bool is_check() const;
 
-        [[nodiscard]] inline bool has_non_pawn() const {
+        [[nodiscard]] bool has_non_pawn() const {
             const Color stm = get_stm();
             return bool(pieces<KNIGHT>(stm) | pieces<BISHOP>(stm) | pieces<ROOK>() | pieces<QUEEN>());
         }
 
-        inline void make_null_move() {
+        void make_null_move() {
             const Color xstm = color_enemy(get_stm());
             const BoardState state_old = state;
 
@@ -130,11 +130,11 @@ namespace core {
             if (state_old.ep != NULL_SQUARE) state.hash.xor_ep(state_old.ep);
         }
 
-        inline void undo_null_move() {
+        void undo_null_move() {
             states.pop_back();
         }
 
-        inline void make_move(Move move, nn::NNUE *nnue = nullptr) {
+        void make_move(Move move, nn::NNUE *nnue = nullptr) {
             const Square from = move.get_from();
             const Square to = move.get_to();
             Piece piece_moved = piece_at(from);
@@ -226,7 +226,7 @@ namespace core {
             state.hash.xor_castle(state.rights);
         }
 
-        inline void undo_move(Move move, nn::NNUE *nnue = nullptr) {
+        void undo_move(Move move, nn::NNUE *nnue = nullptr) {
             const Square from = move.get_from();
             const Square to = move.get_to();
             Piece piece_moved = piece_at(to);
@@ -268,7 +268,7 @@ namespace core {
             states.pop_back();
         }
 
-        inline void load(const std::string &fen) {
+        void load(const std::string &fen) {
             board_clear();
 
             logger.info("Board::load", "Loading fen", fen);
@@ -314,7 +314,7 @@ namespace core {
             logger.info("Board::load", "Finished loading fen");
         }
 
-        [[nodiscard]] inline std::string get_fen() const {
+        [[nodiscard]] std::string get_fen() const {
             std::string fen;
 
             Square square = A8;
@@ -354,7 +354,7 @@ namespace core {
             return fen;
         }
 
-        inline void display() const {
+        void display() const {
             std::vector<std::string> text;
             text.emplace_back("50-move draw counter: " + std::to_string(state.move50));
             text.emplace_back("Hash: " + std::to_string(get_hash()));
@@ -388,7 +388,7 @@ namespace core {
                       << std::endl;
         }
 
-        [[nodiscard]] inline std::vector<unsigned int> to_features() const {
+        [[nodiscard]] std::vector<unsigned int> to_features() const {
             std::vector<unsigned int> result;
             Bitboard bb = occupied();
             while (bb) {
@@ -405,7 +405,7 @@ namespace core {
 
         std::vector<BoardState> states;
 
-        inline void square_clear(Square square, nn::NNUE *nnue = nullptr) {
+        void square_clear(Square square, nn::NNUE *nnue = nullptr) {
             const Piece piece = piece_at(square);
             if (piece.is_null()) return;
 
@@ -418,7 +418,7 @@ namespace core {
             if (nnue) nnue->deactivate(piece, square);
         }
 
-        inline void square_set(Square square, Piece piece, nn::NNUE *nnue = nullptr) {
+        void square_set(Square square, Piece piece, nn::NNUE *nnue = nullptr) {
             assert(piece.is_ok());
             square_clear(square, nnue);
 
@@ -431,19 +431,18 @@ namespace core {
             if (nnue) nnue->activate(piece, square);
         }
 
-        inline void move_piece(Piece piece, Square from, Square to, nn::NNUE *nnue = nullptr) {
+        void move_piece(Piece piece, Square from, Square to, nn::NNUE *nnue = nullptr) {
             assert(piece.is_ok());
 
             square_clear(from, nnue);
             square_set(to, piece, nnue);
         }
 
-        inline void board_clear() {
+        void board_clear() {
 
             logger.info("Board::board_clear", "Clearing board...");
 
             for (Bitboard &i : bb_pieces) i = 0;
-
             for (Bitboard &i : bb_colors) i = 0;
 
             for (Square square = A1; square < 64; square += 1) {
@@ -451,7 +450,6 @@ namespace core {
             }
 
             states.clear();
-
             states.emplace_back();
 
             logger.info("Board::board_clear", "Board has been cleared");

--- a/src/core/magic.h
+++ b/src/core/magic.h
@@ -33,7 +33,7 @@ namespace core {
     extern Bitboard attack_table_bishop[5248];
 
     // Slow naive function of getting the attacked squares of a sliding piece.
-    [[nodiscard]] inline Bitboard attacks_sliding_slow(Square square, Bitboard occupied, PieceType pt) {
+    [[nodiscard]] Bitboard attacks_sliding_slow(Square square, Bitboard occupied, PieceType pt) {
         assert((pt == ROOK) || (pt == BISHOP));
         switch (pt) {
             case ROOK:
@@ -48,7 +48,7 @@ namespace core {
     }
 
     // Converts the magic and the occupancy bitboard into an index in the lookup table.
-    [[nodiscard]] inline unsigned int get_magic_index(const Magic &m, Bitboard occ) {
+    [[nodiscard]] unsigned int get_magic_index(const Magic &m, Bitboard occ) {
 #ifdef BMI2
         return _pext_u64(occ.bb, m.mask.bb);
 #else
@@ -57,7 +57,7 @@ namespace core {
     }
 
     // Initializes magic bitboards by pt.
-    inline void init_magic(const Magic *magics, PieceType pt) {
+    void init_magic(const Magic *magics, PieceType pt) {
         assert((pt == ROOK) || (pt == BISHOP));
         Bitboard occupied[4096], attacked[4096];
 
@@ -221,7 +221,7 @@ namespace core {
             {attack_table_bishop + 5184, 0x40201008040200ULL, 0x208600082060020ULL, 6},
     };
 
-    inline void init_magic() {
+    void init_magic() {
         init_magic(magic_rook, ROOK);
         init_magic(magic_bishop, BISHOP);
     }

--- a/src/core/masks.h
+++ b/src/core/masks.h
@@ -37,10 +37,10 @@ namespace core {
     extern LineType line_type[64][64];
 
     /*
- * Initializes masks. Must be called
- * before calling the move generator.
- */
-    inline void init_masks() {
+     * Initializes masks. Must be called
+     * before calling the move generator.
+     */
+    void init_masks() {
 
         for (Square sq = A1; sq < 64; sq += 1) {
             masks_bit[sq] = 1ULL << sq;

--- a/src/core/move.h
+++ b/src/core/move.h
@@ -104,7 +104,7 @@ namespace core {
         }
 
         // Returns the move in UCI format as a string
-        [[nodiscard]] inline std::string to_uci() const {
+        [[nodiscard]]  std::string to_uci() const {
             std::string res;
             if (is_promo()) {
                 if (!is_special_1() && !is_special_2())
@@ -125,7 +125,7 @@ namespace core {
 
     constexpr Move NULL_MOVE = Move();
 
-    inline std::ostream &operator<<(std::ostream &os, const Move &move) {
+    std::ostream &operator<<(std::ostream &os, const Move &move) {
         os << move.to_uci();
         return os;
     }

--- a/src/core/movegen.h
+++ b/src/core/movegen.h
@@ -24,7 +24,7 @@ namespace core {
 
     // Returns a bitboard of all the squares attacking a given square for the given color
     template<Color color>
-    [[nodiscard]] inline Bitboard get_attackers(const Board &board, Square square) {
+    [[nodiscard]] Bitboard get_attackers(const Board &board, Square square) {
         constexpr Color enemy_color = color_enemy<color>();
 
         Bitboard occupied = board.occupied();
@@ -38,7 +38,7 @@ namespace core {
     }
 
     // Returns a bitboard of all the squares attacking a given square for the side to move
-    [[nodiscard]] inline Bitboard get_attackers(const Board &board, Square square) {
+    [[nodiscard]] Bitboard get_attackers(const Board &board, Square square) {
         if (board.get_stm() == WHITE)
             return get_attackers<WHITE>(board, square);
         else
@@ -47,7 +47,7 @@ namespace core {
 
     // Generates all promotion moves for a pawn from 'from' to 'to'
     // and adds them to the move list 'moves'
-    [[nodiscard]] inline Move *make_promo(Move *moves, Square from, Square to) {
+    [[nodiscard]] Move *make_promo(Move *moves, Square from, Square to) {
         *moves++ = Move(from, to, PROMO_KNIGHT);
         *moves++ = Move(from, to, PROMO_BISHOP);
         *moves++ = Move(from, to, PROMO_ROOK);
@@ -57,7 +57,7 @@ namespace core {
 
     // Generates all promotion captures for a pawn from 'from' to 'to'
     // and adds them to the move list 'moves'
-    [[nodiscard]] inline Move *make_promo_capture(Move *moves, Square from, Square to) {
+    [[nodiscard]] Move *make_promo_capture(Move *moves, Square from, Square to) {
         *moves++ = Move(from, to, PROMO_CAPTURE_KNIGHT);
         *moves++ = Move(from, to, PROMO_CAPTURE_BISHOP);
         *moves++ = Move(from, to, PROMO_CAPTURE_ROOK);
@@ -68,7 +68,7 @@ namespace core {
     // Returns a bitboard of all the squares attacked by a given color
     // 'board' is the board, 'occupied' is a bitboard of all the occupied squares
     template<Color color>
-    [[nodiscard]] inline Bitboard get_attacked_squares(const Board &board, Bitboard occupied) {
+    [[nodiscard]] Bitboard get_attacked_squares(const Board &board, Bitboard occupied) {
 
         constexpr Direction UP_LEFT = color == WHITE ? NORTH_WEST : -NORTH_WEST;
         constexpr Direction UP_RIGHT = color == WHITE ? NORTH_EAST : -NORTH_EAST;
@@ -99,8 +99,8 @@ namespace core {
     // 'empty' - a bitboard of all empty squares
     // 'enemy' - a bitboard of all enemy pieces
     template<bool captures_only, bool pinHV, bool pinDA>
-    [[nodiscard]] inline Move *gen_moves_from_pieces(const Board &board, Move *moves, Bitboard pieces, Bitboard mask_special,
-                                       Bitboard occupied, Bitboard empty, Bitboard enemy) {
+    [[nodiscard]] Move *gen_moves_from_pieces(const Board &board, Move *moves, Bitboard pieces, Bitboard mask_special,
+                                              Bitboard occupied, Bitboard empty, Bitboard enemy) {
 
         // Iterate through the pieces
         while (pieces) {
@@ -148,8 +148,8 @@ namespace core {
     // 'moveD' - a bitboard indicating pieces which can move diagonally
     // 'moveA' - a bitboard indicating pieces which can move anti-diagonally
     template<Color color, bool captures_only>
-    [[nodiscard]] inline Move *gen_pawn_moves(const Board &board, Move *moves, Square king, Bitboard mask_check,
-                         Bitboard moveH, Bitboard moveV, Bitboard moveD, Bitboard moveA) {
+    [[nodiscard]] Move *gen_pawn_moves(const Board &board, Move *moves, Square king, Bitboard mask_check,
+                                       Bitboard moveH, Bitboard moveV, Bitboard moveD, Bitboard moveA) {
 
         // Define enemy color
         constexpr Color enemy_color = color_enemy<color>();
@@ -334,8 +334,8 @@ namespace core {
 
     // Generates all the legal king moves.
     template<bool captures_only>
-    [[nodiscard]] inline Move *gen_king_moves(const Board &board, Move *moves, Square king,
-                                Bitboard squares_safe, Bitboard empty, Bitboard enemy) {
+    [[nodiscard]] Move *gen_king_moves(const Board &board, Move *moves, Square king,
+                                       Bitboard squares_safe, Bitboard empty, Bitboard enemy) {
 
         // Calculate all safe squares that the king can move to
         Bitboard king_target = masks_king[king] & squares_safe;
@@ -362,7 +362,7 @@ namespace core {
     }
 
     // Returns the "to" squares which evades check.
-    [[nodiscard]] inline Bitboard gen_check_mask(const Board &board, Square king, Bitboard checkers) {
+    [[nodiscard]] Bitboard gen_check_mask(const Board &board, Square king, Bitboard checkers) {
         unsigned int checks = checkers.pop_count();
         if (checks == 0) {
             return 0xffffffffffffffffULL;
@@ -381,9 +381,9 @@ namespace core {
 
     // Generates all the legal slider and knight moves using the gen_moves_from_pieces utility.
     template<bool captures_only>
-    [[nodiscard]] inline Move *gen_slider_and_jumper(const Board &board, Move *moves, Bitboard pieces,
-                                       Bitboard occupied, Bitboard empty, Bitboard enemy, Bitboard checkMask,
-                                       Bitboard pinHV, Bitboard pinDA) {
+    [[nodiscard]] Move *gen_slider_and_jumper(const Board &board, Move *moves, Bitboard pieces,
+                                              Bitboard occupied, Bitboard empty, Bitboard enemy, Bitboard checkMask,
+                                              Bitboard pinHV, Bitboard pinDA) {
         Bitboard pinnedHV = pinHV & pieces;
         Bitboard pinnedDA = pinDA & pieces;
         pieces &= ~(pinnedHV | pinnedDA);
@@ -401,7 +401,7 @@ namespace core {
 
     // Generates all the legal moves in a board.
     template<Color color, bool captures_only>
-    [[nodiscard]] inline Move *gen_moves(const Board &board, Move *moves) {
+    [[nodiscard]] Move *gen_moves(const Board &board, Move *moves) {
         // Define enemy color
         constexpr Color enemyColor = color_enemy<color>();
 
@@ -525,7 +525,7 @@ namespace core {
 
     // Wrapper around the stm template.
     template<bool captures_only>
-    [[nodiscard]] inline Move *gen_moves(const Board &board, Move *moves) {
+    [[nodiscard]] Move *gen_moves(const Board &board, Move *moves) {
         if (board.get_stm() == WHITE) {
             return gen_moves<WHITE, captures_only>(board, moves);
         } else {
@@ -534,7 +534,7 @@ namespace core {
     }
 
     // Wrapper around captures only template.
-    [[nodiscard]] inline Move *gen_moves(const Board &board, Move *moves, bool captures_only) {
+    [[nodiscard]] Move *gen_moves(const Board &board, Move *moves, bool captures_only) {
         if (captures_only) {
             return gen_moves<true>(board, moves);
         } else {

--- a/src/core/zobrist.h
+++ b/src/core/zobrist.h
@@ -30,7 +30,7 @@ namespace core {
 
         explicit Zobrist(U64 hash) : hash(hash) {}
 
-        [[nodiscard]] inline operator U64() const {
+        [[nodiscard]] operator U64() const {
             return hash;
         }
 

--- a/src/network/adam.h
+++ b/src/network/adam.h
@@ -23,7 +23,7 @@ namespace nn {
 
     class Adam {
     public:
-        Adam(float learning_rate) : LR(learning_rate), m_gradient(), v_gradient() {}
+        explicit Adam(float learning_rate) : LR(learning_rate), m_gradient(), v_gradient() {}
 
         void update(const std::vector<Gradient> &gradients, Network &network) {
             Gradient total;
@@ -57,7 +57,7 @@ namespace nn {
             }
         }
 
-        void apply_gradient(float &target, float &m, float &v, float grad) {
+        void apply_gradient(float &target, float &m, float &v, float grad) const {
             m = BETA1 * m + (1.0f - BETA1) * grad;
             v = BETA2 * v + (1.0f - BETA2) * grad * grad;
 

--- a/src/network/data_parser.h
+++ b/src/network/data_parser.h
@@ -99,14 +99,14 @@ namespace nn {
                 }
             }
 
-            Color stm = COLOR_EMPTY;
+            Color stm;
             idx++;
             if (fen[idx] == 'w')
                 stm = WHITE;
             else if (fen[idx] == 'b')
                 stm = BLACK;
             else {
-                throw 1;
+                throw std::runtime_error("Invalid color specified in FEN " + entry + ".");
             }
 
             int eval_int = std::stoi(eval);

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -52,30 +52,30 @@ namespace nn {
         Network(const std::string &network_path) {
             std::ifstream file(network_path, std::ios::in | std::ios::binary);
             if (!file.is_open()) {
-                logger.print("Unable to open:", network_path);
-                std::random_device rd;
-                std::mt19937 mt(rd());
-                l0.randomize(mt);
-                l1.randomize(mt);
-            } else {
-                int magic;
-                file.read(reinterpret_cast<char *>(&magic), sizeof(magic));
-
-                if (magic != MAGIC) {
-                    logger.print("Invalid network file", network_path, "with magic", magic);
-                    throw std::invalid_argument("Invalid network file with magic " + std::to_string(magic));
-                }
-
-                l0.load_from_file(file);
-                l1.load_from_file(file);
-
-                file.close();
-
-                logger.print("Loaded network file", network_path, "for training");
+                logger.print("Unable to open: ", network_path);
+                randomize();
+                return;
             }
+
+            int magic;
+            file.read(reinterpret_cast<char *>(&magic), sizeof(magic));
+
+            if (magic != MAGIC) {
+                logger.print("Invalid network file: ", network_path, " with magic: ", magic);
+                throw std::invalid_argument("Invalid network file with magic: " + std::to_string(magic));
+            }
+
+            l0.load_from_file(file);
+            l1.load_from_file(file);
+
+            logger.print("Loaded network file: ", network_path);
         }
 
         Network() {
+            randomize();
+        }
+
+        void randomize() {
             std::random_device rd;
             std::mt19937 mt(rd());
             l0.randomize(mt);

--- a/src/search/pv_array.h
+++ b/src/search/pv_array.h
@@ -1,0 +1,46 @@
+// WhiteCore is a C++ chess engine
+// Copyright (c) 2023 Balázs Szilágyi
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+#include "../core/move.h"
+
+namespace search {
+    struct PVArray {
+
+        core::Move array[500][500];
+        Ply length[500];
+
+        std::string get_line() {
+            std::string line;
+            for (int i = 0; i < length[0]; i++) {
+                line += array[0][i].to_uci() + " ";
+            }
+            return line;
+        }
+
+        core::Move get_best_move() {
+            return array[0][0];
+        }
+
+        void update(Ply ply, core::Move move) {
+            array[ply][ply] = move;
+            for (Ply i = ply + 1; i < length[ply + 1]; i++) {
+                array[ply][i] = array[ply + 1][i];
+            }
+            length[ply] = length[ply + 1];
+        }
+    };
+}

--- a/src/search/search_limits.h
+++ b/src/search/search_limits.h
@@ -24,23 +24,23 @@
 namespace search {
     struct Limits {
         std::optional<int64_t> time_left, increment, moves_to_go, depth, move_time, max_nodes;
+        
+        static Limits create_node_limit(int64_t max_nodes) {
+            Limits limit;
+            limit.max_nodes = max_nodes;
+            return limit;
+        }
+        
+        static Limits create_depth_limit(int64_t max_depth) {
+            Limits limit;
+            limit.depth = max_depth;
+            return limit;
+        }
+
+        static Limits create_time_limit(int64_t max_time) {
+            Limits limit;
+            limit.move_time = max_time;
+            return limit;
+        }
     };
-
-    inline Limits create_node_limit(int64_t max_nodes) {
-        Limits limit;
-        limit.max_nodes = max_nodes;
-        return limit;
-    }
-
-    inline Limits create_depth_limit(int64_t max_depth) {
-        Limits limit;
-        limit.depth = max_depth;
-        return limit;
-    }
-
-    inline Limits create_time_limit(int64_t max_time) {
-        Limits limit;
-        limit.move_time = max_time;
-        return limit;
-    }
 } // namespace search

--- a/src/search/search_manager.h
+++ b/src/search/search_manager.h
@@ -25,32 +25,32 @@
 namespace search {
     class SearchManager {
     public:
-        inline void allocate_threads(unsigned int thread_count) {
+        void allocate_threads(unsigned int thread_count) {
             allocated_threads = thread_count;
         }
 
-        inline void allocate_hash(unsigned int MB) {
+        void allocate_hash(unsigned int MB) {
             shared.tt.resize(MB);
         }
 
-        inline void set_limits(const Limits &limits) {
+        void set_limits(const Limits &limits) {
             shared.tm.init(limits);
         }
 
-        inline int64_t get_elapsed_time() {
+        int64_t get_elapsed_time() {
             return shared.tm.get_elapsed_time();
         }
 
-        inline int64_t get_node_count() {
+        int64_t get_node_count() {
             return shared.node_count;
         }
 
-        inline void set_uci_mode(bool uci_mode) {
+        void set_uci_mode(bool uci_mode) {
             shared.uci_mode = uci_mode;
         }
 
         template<bool wait_to_finish>
-        inline void join() {
+        void join() {
             if (!wait_to_finish) {
                 shared.is_searching = false;
             }
@@ -63,7 +63,7 @@ namespace search {
         }
 
         template<bool block>
-        inline void search(const core::Board &board) {
+        void search(const core::Board &board) {
             join<false>();
             for (unsigned int thread_id = 0; thread_id < allocated_threads; thread_id++) {
                 threads.emplace_back(shared, thread_id);
@@ -78,16 +78,16 @@ namespace search {
             if (block) join<true>();
         }
 
-        inline void stop() {
+        void stop() {
             join<false>();
         }
 
-        inline std::pair<core::Move, Score> get_result() {
+        std::pair<core::Move, Score> get_result() {
             join<true>();
             return {shared.best_move, shared.eval};
         }
 
-        inline void tt_clear() {
+        void tt_clear() {
             shared.tt.clear();
         }
 

--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -30,7 +30,7 @@ namespace search {
 
     extern Depth lmr_reductions[200][MAX_PLY + 1];
 
-    inline void init_lmr() {
+    void init_lmr() {
         for (int made_moves = 0; made_moves < 200; made_moves++) {
             for (Depth depth = 0; depth < MAX_PLY + 1; depth++) {
                 double moves_log = made_moves == 0 ? 0 : std::log(made_moves);

--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -17,6 +17,7 @@
 
 #include "../core/board.h"
 #include "../network/nnue.h"
+#include "pv_array.h"
 #include "history.h"
 #include "move_list.h"
 #include "time_manager.h"
@@ -78,43 +79,50 @@ namespace search {
         SharedMemory &shared;
         std::thread th;
         unsigned int id;
-        core::Move pv_array[500][500];
-        Ply pv_length[500];
+        PVArray pv;
+
         History history;
 
-        std::string get_pv_line() {
-            std::string pv;
-            for (int i = 0; i < pv_length[0]; i++) {
-                pv += pv_array[0][i].to_uci() + " ";
-            }
-            return pv;
+        void search() {
+            init_search();
+            iterative_deepening();
+            finish_search();
         }
 
-        void search() {
-            history.clear(); // TODO remove this?
+        void init_search() {
+            history.clear();
             shared.best_move = core::NULL_MOVE;
+        }
+
+        void iterative_deepening() {
             Score prev_score = 0;
-            for (Depth depth = 1; depth <= shared.tm.get_max_depth(); depth++) {
+            for (Depth depth = 1; depth <= shared.tm.get_max_depth() && shared.is_searching; depth++) {
                 Score score = prev_score = aspiration_window(depth, prev_score);
 
-                if (shared.is_searching && id == 0) {
-                    int64_t elapsed_time = shared.tm.get_elapsed_time();
-
-                    if (shared.uci_mode) {
-                        logger.print("info", "depth", int(depth), "nodes", shared.node_count,
-                                     "score", "cp", score, "time", elapsed_time,
-                                     "nps", calculate_nps(elapsed_time, shared.node_count),
-                                     "pv", get_pv_line());
-                    }
-
-                    shared.best_move = pv_array[0][0];
-                    shared.eval = score;
-                }
-
-                if (!shared.is_searching) {
-                    break;
-                }
+                handle_iteration(score, depth);
             }
+        }
+
+        void handle_iteration(Score score, Depth depth) {
+            if (shared.is_searching && id == 0) {
+                handle_uci(score, depth);
+                shared.best_move = pv.get_best_move();
+                shared.eval = score;
+            }
+        }
+
+        void handle_uci(Score score, Depth depth) {
+            int64_t elapsed_time = shared.tm.get_elapsed_time();
+
+            if (shared.uci_mode) {
+                logger.print("info", "depth", int(depth), "nodes", shared.node_count,
+                             "score", "cp", score, "time", elapsed_time,
+                             "nps", calculate_nps(elapsed_time, shared.node_count),
+                             "pv", pv.get_line());
+            }
+        }
+
+        void finish_search() {
             if (id == 0) {
                 shared.is_searching = false;
                 if (shared.uci_mode) {
@@ -190,8 +198,9 @@ namespace search {
             core::Move best_move = core::NULL_MOVE;
             Score best_score = -INF_SCORE;
 
-            if (id == 0)
-                pv_length[ss->ply] = ss->ply;
+            if (id == 0) {
+                pv.length[ss->ply] = ss->ply;
+            }
 
             if ((shared.node_count & 1023) == 0) {
                 manage_resources();
@@ -201,13 +210,13 @@ namespace search {
                 return UNKNOWN_SCORE;
             }
 
-            if (non_root_node) {
-                if (board.is_draw()) {
-                    return 0;
-                }
+            if (non_root_node && board.is_draw()) {
+                return 0;
             }
 
-            if (in_check) depth++;
+            if (in_check) {
+                depth++;
+            }
 
             std::optional<TTEntry> entry = shared.tt.probe(board.get_hash());
             TTFlag flag = TT_ALPHA;
@@ -321,13 +330,8 @@ namespace search {
                     best_move = move;
 
                     if (id == 0) {
-                        pv_array[ss->ply][ss->ply] = move;
-                        for (Ply i = ss->ply + 1; i < pv_length[ss->ply + 1]; i++) {
-                            pv_array[ss->ply][i] = pv_array[ss->ply + 1][i];
-                        }
-                        pv_length[ss->ply] = pv_length[ss->ply + 1];
+                        pv.update(ss->ply, move);
                     }
-
 
                     if (score > alpha) {
                         flag = TT_EXACT;

--- a/src/search/time_manager.h
+++ b/src/search/time_manager.h
@@ -23,15 +23,8 @@ namespace search {
     class TimeManager {
     public:
         void init(const Limits &limits) {
-            int64_t moves_to_go = limits.moves_to_go.value_or(30);
-            int64_t increment = limits.increment.value_or(0);
-            if (limits.time_left) {
-                int64_t time_left = limits.time_left.value();
-                allocated_time = (time_left + moves_to_go * increment) / moves_to_go;
-                allocated_time = std::min(allocated_time, time_left);
-            } else {
-                allocated_time = limits.move_time.value_or(INF_TIME);
-            }
+
+            calculate_allocated_time(limits);
 
             max_nodes = limits.max_nodes.value_or(INF_NODES);
             max_depth = limits.depth.value_or(MAX_PLY);
@@ -58,5 +51,17 @@ namespace search {
 
     private:
         int64_t start_time, allocated_time, end_time, max_nodes, max_depth;
+
+        void calculate_allocated_time(const Limits &limits) {
+            int64_t moves_to_go = limits.moves_to_go.value_or(30);
+            int64_t increment = limits.increment.value_or(0);
+            if (limits.time_left) {
+                int64_t time_left = limits.time_left.value();
+                allocated_time = (time_left + moves_to_go * increment) / moves_to_go;
+                allocated_time = std::min(allocated_time, time_left);
+            } else {
+                allocated_time = limits.move_time.value_or(INF_TIME);
+            }
+        }
     };
 } // namespace search

--- a/src/search/time_manager.h
+++ b/src/search/time_manager.h
@@ -33,19 +33,19 @@ namespace search {
             end_time = start_time + allocated_time - MOVE_OVERHEAD;
         }
 
-        [[nodiscard]] inline bool time_left() const {
+        [[nodiscard]] bool time_left() const {
             return now() < end_time;
         }
 
-        [[nodiscard]] inline int64_t get_elapsed_time() const {
+        [[nodiscard]] int64_t get_elapsed_time() const {
             return now() - start_time;
         }
 
-        [[nodiscard]] inline Depth get_max_depth() const {
+        [[nodiscard]] Depth get_max_depth() const {
             return max_depth;
         }
 
-        [[nodiscard]] inline int64_t get_max_nodes() const {
+        [[nodiscard]] int64_t get_max_nodes() const {
             return max_nodes;
         }
 

--- a/src/selfplay/data_entry.h
+++ b/src/selfplay/data_entry.h
@@ -32,7 +32,7 @@ namespace selfplay {
             case BLACK_WIN:
                 return "-1";
         }
-        return "HMMMM";
+        return "";
     }
 
     struct DataEntry {
@@ -47,17 +47,10 @@ namespace selfplay {
                                                                                                                            result(result) {}
 
         std::string to_string() const {
-            std::string res = fen;
-            res += ";";
-            res += std::to_string(ply);
-            res += ";";
-            res += best_move.to_uci();
-            res += ";";
-            res += std::to_string(int(eval));
-            res += ";";
-            res += get_wdl(result.value_or(DRAW));
-            res += ";";
-            return res;
+            std::stringstream ss;
+            ss << fen << ";" << ply << ";" << best_move.to_uci() << ";"
+               << int(eval) << ";" << get_wdl(result.value_or(DRAW)) << ";";
+            return ss.str();
         }
     };
 

--- a/src/selfplay/data_entry.h
+++ b/src/selfplay/data_entry.h
@@ -23,7 +23,7 @@ namespace selfplay {
         BLACK_WIN
     };
 
-    inline std::string get_wdl(const GameResult &result) {
+    std::string get_wdl(const GameResult &result) {
         switch (result) {
             case WHITE_WIN:
                 return "1";

--- a/src/selfplay/selfplay.h
+++ b/src/selfplay/selfplay.h
@@ -35,7 +35,7 @@ namespace selfplay {
 
     const unsigned int PROGRESS_BAR_WIDTH = 25;
 
-    inline std::string get_date() {
+    std::string get_date() {
         auto t = std::time(nullptr);
         auto tm = *std::localtime(&t);
         std::stringstream ss;
@@ -43,7 +43,7 @@ namespace selfplay {
         return ss.str();
     }
 
-    inline std::optional<GameResult> get_game_result(const core::Board &board) {
+    std::optional<GameResult> get_game_result(const core::Board &board) {
 
         if (board.is_draw()) return DRAW;
 
@@ -61,7 +61,7 @@ namespace selfplay {
         return std::nullopt;
     }
 
-    inline void run_game(Engine &engine, const search::Limits &limits, const std::string &starting_fen, std::vector<DataEntry> &entries, unsigned int hash_size = DEFAULT_HASH_SIZE, const unsigned int thread_count = DEFAULT_THREAD_COUNT) {
+    void run_game(Engine &engine, const search::Limits &limits, const std::string &starting_fen, std::vector<DataEntry> &entries, unsigned int hash_size = DEFAULT_HASH_SIZE, const unsigned int thread_count = DEFAULT_THREAD_COUNT) {
         engine.init(hash_size, thread_count);
         core::Board board;
         board.load(starting_fen);
@@ -89,7 +89,7 @@ namespace selfplay {
         }
     }
 
-    inline void gen_games(const search::Limits &limits, const std::vector<std::string> &starting_fens, const std::string &output_path) {
+    void gen_games(const search::Limits &limits, const std::vector<std::string> &starting_fens, const std::string &output_path) {
 
         Engine engine;
 
@@ -121,7 +121,7 @@ namespace selfplay {
         file.close();
     }
 
-    inline void combine_data(const std::string &path, const std::string &output_file) {
+    void combine_data(const std::string &path, const std::string &output_file) {
 
         logger.print("Combining files...");
 
@@ -139,7 +139,7 @@ namespace selfplay {
         logger.print("Finished combining");
     }
 
-    inline void start_generation(const search::Limits &limits, const std::string &book_path, const std::string &output_path, unsigned int thread_count, int dropout) {
+    void start_generation(const search::Limits &limits, const std::string &book_path, const std::string &output_path, unsigned int thread_count, int dropout) {
         game_count = 0;
         position_count = 0;
 

--- a/src/tests/perft.h
+++ b/src/tests/perft.h
@@ -48,7 +48,7 @@ namespace test {
         return nodes;
     }
 
-    inline void test_perft() {
+    void test_perft() {
 
         struct Test {
             std::string fen;

--- a/src/tests/repetition.h
+++ b/src/tests/repetition.h
@@ -40,7 +40,7 @@ namespace test {
 
         for (const Test &test : tests) {
             board.load(test.fen);
-            for (const std::string& str : test.moves) {
+            for (const std::string &str : test.moves) {
                 core::Move move = uci::move_from_string(board, str);
                 board.make_move(move);
             }

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -23,7 +23,7 @@
 
 namespace test {
 
-    inline void run() {
+    void run() {
         test_hash();
         test_repetition();
         test_perft();

--- a/src/uci/option.h
+++ b/src/uci/option.h
@@ -43,17 +43,16 @@ namespace uci {
         }
 
         std::string to_string() const {
-            std::string res = "option";
-
-            res += " name " + name;
-            res += " type " + type;
-            res += " default " + default_value;
+            std::stringstream res;
+            res << "option"
+                << " name " << name
+                << " type " << type
+                << " default " << default_value;
             if (min_value && max_value) {
-                res += " min " + std::to_string(min_value.value());
-                res += " max " + std::to_string(max_value.value());
+                res << " min " << min_value.value()
+                    << " max " << max_value.value();
             }
-
-            return res;
+            return res.str();
         }
 
         void set_value(const std::optional<std::string> &new_value) {

--- a/src/utils/bench.h
+++ b/src/utils/bench.h
@@ -62,7 +62,7 @@ void run_bench() {
     sm.allocate_threads(1);
     sm.allocate_hash(32);
 
-    search::Limits limits = search::create_depth_limit(11);
+    search::Limits limits = search::Limits::create_depth_limit(11);
 
     int64_t nodes = 0;
     int64_t start_time = now();

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -39,17 +39,17 @@ struct Logger {
     }
 
     template<typename T, typename... Args>
-    inline void print(T a, Args... args) {
+    void print(T a, Args... args) {
         std::cout << a << " ";
         print(args...);
     }
 
-    inline void print() {
+    void print() {
         std::cout << std::endl;
     }
 
     template<typename T, typename... Args>
-    inline void info(T a, Args... args) {
+    void info(T a, Args... args) {
 #ifdef LOGGING
         file << "[INFO] " << a << "(): ";
         log(args...);
@@ -57,7 +57,7 @@ struct Logger {
     }
 
     template<typename T, typename... Args>
-    inline void error(T a, Args... args) {
+    void error(T a, Args... args) {
 #ifdef LOGGING
         file << "[INFO] " << a << "(): ";
         log(args...);
@@ -65,12 +65,12 @@ struct Logger {
     }
 
     template<typename T, typename... Args>
-    inline void log(T a, Args... args) {
+    void log(T a, Args... args) {
         file << a << " ";
         log(args...);
     }
 
-    inline void log() {
+    void log() {
         file << std::endl;
     }
 };

--- a/src/utils/split.h
+++ b/src/utils/split.h
@@ -19,7 +19,7 @@
 
 #include <random>
 
-inline void split_data(const std::string &input, const std::string &output1, const std::string &output2, int rate) {
+void split_data(const std::string &input, const std::string &output1, const std::string &output2, int rate) {
     std::ifstream in(input, std::ios::in);
     std::ofstream out1(output1, std::ios::out | std::ios::app);
     std::ofstream out2(output2, std::ios::out | std::ios::app);

--- a/src/utils/utilities.h
+++ b/src/utils/utilities.h
@@ -32,7 +32,7 @@ constexpr Color color_enemy() {
         return WHITE;
 }
 
-inline Color color_enemy(Color color) {
+Color color_enemy(Color color) {
     return color == WHITE ? BLACK : WHITE;
 }
 
@@ -44,12 +44,12 @@ constexpr unsigned int square_to_file(Square square) {
     return square & 7;
 }
 
-inline std::string format_square(Square square) {
+std::string format_square(Square square) {
     return std::string() + (char) ('a' + (char) square % 8) + (char) ('1' + (char) (square / 8));
 }
 
 // Function that converts an uci format square string into an actual square.
-inline Square square_from_string(const std::string &s) {
+Square square_from_string(const std::string &s) {
     if (s[0] == '-') {
         return NULL_SQUARE;
     } else if ('a' <= s[0] && s[0] <= 'z') {
@@ -71,7 +71,7 @@ constexpr Square square_flip(Square sq) {
     return Square(int(sq) ^ 56);
 }
 
-inline Piece piece_from_char(char c) {
+Piece piece_from_char(char c) {
     Piece piece;
 
     if ('a' <= c && c <= 'z') {
@@ -108,7 +108,7 @@ inline Piece piece_from_char(char c) {
     return piece;
 }
 
-inline char char_from_piece(Piece piece) {
+char char_from_piece(Piece piece) {
     char base;
     switch (piece.type) {
         case PAWN:
@@ -149,22 +149,22 @@ constexpr int64_t calculate_nps(int64_t time, int64_t nodes) {
     return nodes * 1000 / (time + 1);
 }
 
-inline Square operator+(Square a, int b) {
+Square operator+(Square a, int b) {
     return Square(int(a) + b);
 }
 
-inline Square operator-(Square a, int b) {
+Square operator-(Square a, int b) {
     return Square(int(a) - b);
 }
 
-inline Square operator+=(Square &a, int b) {
+Square operator+=(Square &a, int b) {
     return a = a + b;
 }
 
-inline Square operator-=(Square &a, int b) {
+Square operator-=(Square &a, int b) {
     return a = a - b;
 }
 
-inline int64_t now() {
+int64_t now() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 };


### PR DESCRIPTION
STC:
```
ELO   | -6.22 +- 4.69 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | -2.99 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 11456 W: 3023 L: 3228 D: 5205
```

Elo loss at STC is most likely caused by the removal of inline hints, which has resulted a minimal speed loss and shouldn't be noticeable at LTC. 

Bench: 3364651