### PR TITLE
Added prefetch to improve transposition table performance

### DIFF
--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -301,6 +301,8 @@ namespace search {
                 board.make_move(move, &nnue);
                 Score score;
 
+                shared.tt.prefetch(board.get_hash());
+
                 if (!in_check && depth >= 3 && made_moves >= 4 && !move.is_promo() && move.is_quiet()) {
                     Depth R = lmr_reductions[depth][made_moves];
 

--- a/src/search/tt.h
+++ b/src/search/tt.h
@@ -90,6 +90,10 @@ namespace search {
             }
         }
 
+        void prefetch(U64 hash) {
+            __builtin_prefetch(get_entry(hash), 0);
+        }
+
         core::Move get_hash_move(U64 hash) {
             TTEntry *entry = get_entry(hash);
             if (entry->hash == hash)


### PR DESCRIPTION
STC:
```
ELO   | 26.78 +- 11.28 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1976 W: 610 L: 458 D: 908
```

Bench: 3364651