### PR TITLE
Replace quiet moves vector with array for performance optimization

### DIFF
--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -285,7 +285,9 @@ namespace search {
                 return in_check ? mate_ply : 0;
             }
 
-            std::vector<core::Move> quiet_moves;
+            core::Move quiet_moves[200];
+            core::Move *next_quiet_move = quiet_moves;
+
             bool skip_quiets = false;
             int made_moves = 0;
             while (!move_list.empty()) {
@@ -333,8 +335,8 @@ namespace search {
 
                     if (move.is_quiet()) {
                         history.add_cutoff(move, depth, ss->ply);
-                        for (const core::Move &m : quiet_moves) {
-                            history.decrease_history(m, depth);
+                        for (core::Move *current_move = quiet_moves; current_move != next_quiet_move; current_move++) {
+                            history.decrease_history(*current_move, depth);
                         }
                     }
 
@@ -357,7 +359,7 @@ namespace search {
                 }
 
                 made_moves++;
-                if (move.is_quiet()) quiet_moves.emplace_back(move);
+                if (move.is_quiet()) *next_quiet_move++ = move;
             }
 
             shared.tt.save(board.get_hash(), depth, best_score, flag, best_move);


### PR DESCRIPTION
Suggested by @Disservin

STC:
```
ELO   | 6.95 +- 5.03 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 9648 W: 2640 L: 2447 D: 4561
```

Bench: 3366289