### PR TITLE
Aggressive lmp

### DIFF
--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -317,7 +317,7 @@ namespace search {
                 if (skip_quiets && move.is_quiet() && !move.is_promo()) continue;
 
                 if (non_root_node && non_pv_node && !in_check) {
-                    if (depth <= 5 && made_moves >= 5 + depth * depth) {
+                    if (depth <= 5 && made_moves >= 5 + depth * depth / (2 - improving)) {
                         skip_quiets = true;
                     }
 


### PR DESCRIPTION
STC:
```
ELO   | 3.73 +- 3.01 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 26984 W: 7269 L: 6979 D: 12736
```

LTC:
```
ELO   | 4.90 +- 3.79 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 15400 W: 3799 L: 3582 D: 8019
```

Bench: 2542586