### PR TITLE
TM Improvements

### DIFF
--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -124,6 +124,12 @@ namespace search {
                 Score score = prev_score = aspiration_window(depth, prev_score);
 
                 handle_iteration(score, depth);
+
+                bool should_continue = shared.tm.handle_iteration();
+
+                if (!should_continue) {
+                    break;
+                }
             }
         }
 

--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -120,16 +120,15 @@ namespace search {
 
         void iterative_deepening() {
             Score prev_score = 0;
+            int bm_stability = 0;
+            core::Move prev_bm = core::NULL_MOVE;
+
             for (Depth depth = 1; depth <= shared.tm.get_max_depth() && shared.is_searching; depth++) {
                 Score score = prev_score = aspiration_window(depth, prev_score);
 
                 handle_iteration(score, depth);
 
-                bool should_continue = shared.tm.handle_iteration();
-
-                if (!should_continue) {
-                    break;
-                }
+                manage_time(prev_bm, bm_stability, depth);
             }
         }
 
@@ -138,6 +137,29 @@ namespace search {
                 handle_uci(score, depth);
                 shared.best_move = pv.get_best_move();
                 shared.eval = score;
+            }
+        }
+
+        void manage_time(core::Move &prev_bm, int &bm_stability, Depth depth) {
+
+            const core::Move bm = pv.get_best_move();
+
+            if (depth >= 5) {
+                if (bm == prev_bm) {
+                    bm_stability++;
+                } else {
+                    bm_stability = 0;
+                }
+            }
+
+            prev_bm = bm;
+
+            if (id == 0) {
+                bool should_continue = shared.tm.handle_iteration(bm_stability);
+
+                if (!should_continue) {
+                    shared.is_searching = false;
+                }
             }
         }
 

--- a/src/search/time_manager.h
+++ b/src/search/time_manager.h
@@ -49,9 +49,13 @@ namespace search {
             return max_nodes;
         }
 
-        bool handle_iteration() {
+        bool handle_iteration(int bm_stability) {
 
-            update_end_time(1.0);
+            const double bm_scale = 1.2 - std::min(bm_stability, 10) * 0.04;
+
+            double scale = bm_scale;
+
+            update_end_time(scale);
 
             return now() < opt_end_time;
         }

--- a/src/search/tt.h
+++ b/src/search/tt.h
@@ -42,7 +42,7 @@ namespace search {
         TTFlag flag;          // 1 byte
     };
 
-        static_assert(sizeof(TTEntry) == 16);
+    static_assert(sizeof(TTEntry) == 16);
 
     class TT {
     public:


### PR DESCRIPTION
TM 1 vs master at STC:
```
ELO   | 13.08 +- 7.49 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4384 W: 1246 L: 1081 D: 2057
```

TM 2 vs TM 1 at STC:
```
ELO   | 4.78 +- 3.78 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 16848 W: 4492 L: 4260 D: 8096
```

TM 2 vs master at LTC:
```
ELO   | 12.95 +- 7.24 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4376 W: 1164 L: 1001 D: 2211
```

Bench: 2542586