### PR TITLE
Do not save bestmove to TT in case of alpha scores

### DIFF
--- a/src/search/tt.h
+++ b/src/search/tt.h
@@ -78,6 +78,10 @@ namespace search {
         void save(U64 hash, Depth depth, Score eval, TTFlag flag, core::Move best_move) {
             TTEntry *entry = get_entry(hash);
 
+            if (flag == TT_ALPHA && entry->hash) {
+                best_move = core::NULL_MOVE;
+            }
+
             if (entry->hash != hash || best_move.is_ok()) {
                 entry->hash_move = best_move;
             }

--- a/src/search/tt.h
+++ b/src/search/tt.h
@@ -78,7 +78,7 @@ namespace search {
         void save(U64 hash, Depth depth, Score eval, TTFlag flag, core::Move best_move) {
             TTEntry *entry = get_entry(hash);
 
-            if (flag == TT_ALPHA && entry->hash) {
+            if (flag == TT_ALPHA && entry->hash == hash) {
                 best_move = core::NULL_MOVE;
             }
 


### PR DESCRIPTION
STC:
```
ELO   | 4.73 +- 3.73 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 17488 W: 4718 L: 4480 D: 8290
```

LTC:
```
ELO   | 4.81 +- 3.75 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 15888 W: 3939 L: 3719 D: 8230
```

Bench: 2478527