### PR TITLE
SEE capture ordering

### DIFF
--- a/src/search/move_list.h
+++ b/src/search/move_list.h
@@ -27,10 +27,11 @@ namespace search {
 
         static constexpr unsigned int MOVE_SCORE_HASH = 10'000'000;
         static constexpr unsigned int MOVE_SCORE_PROMO = 9'000'000;
-        static constexpr unsigned int MOVE_SCORE_CAPTURE = 8'000'000;
+        static constexpr unsigned int MOVE_SCORE_GOOD_CAPTURE = 8'000'000;
         static constexpr unsigned int MOVE_SCORE_FIRST_KILLER = 7'000'000;
         static constexpr unsigned int MOVE_SCORE_SECOND_KILLER = 6'000'000;
         static constexpr unsigned int MOVE_SCORE_COUNTER = 5'000'000;
+        static constexpr unsigned int MOVE_SCORE_BAD_CAPTURE = 4'000'000;
 
     public:
         MoveList(const core::Board &board, const core::Move &hash_move, const core::Move &last_move, const History &history, const Ply &ply) : current(0), board(board),
@@ -77,7 +78,7 @@ namespace search {
             } else if (move.is_promo()) {
                 return MOVE_SCORE_PROMO;
             } else if (move.is_capture()) {
-                return MOVE_SCORE_CAPTURE + get_mvv_lva(move);
+                return (see(board, move, 0) ? MOVE_SCORE_GOOD_CAPTURE : MOVE_SCORE_BAD_CAPTURE) + get_mvv_lva(move);
             } else if (move == history.killer_moves[ply][0]) {
                 return MOVE_SCORE_FIRST_KILLER;
             } else if (move == history.killer_moves[ply][1]) {


### PR DESCRIPTION
STC:
```
ELO   | 26.18 +- 11.03 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2008 W: 603 L: 452 D: 953
```

LTC:
```
ELO   | 19.22 +- 9.10 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2696 W: 723 L: 574 D: 1399
```

Bench: 2266395