### PR TITLE
SEE PVS prune quiets

### DIFF
--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -344,7 +344,14 @@ namespace search {
 
                 if (skip_quiets && move.is_quiet() && !move.is_promo()) continue;
 
-                if (non_root_node && non_pv_node && !in_check) {
+                if (non_root_node && non_pv_node && !in_check && std::abs(best_score) < WORST_MATE) {
+
+                    if (move.is_quiet()) {
+                        if (depth <= 6 && !see(board, move, -depth * 100)) {
+                            continue;
+                        }
+                    }
+
                     if (depth <= 5 && made_moves >= 5 + depth * depth / (2 - improving)) {
                         skip_quiets = true;
                     }


### PR DESCRIPTION
STC:
```
ELO   | 5.21 +- 4.03 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 14544 W: 3829 L: 3611 D: 7104
```

LTC:
```
ELO   | 2.95 +- 2.32 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 40240 W: 9585 L: 9243 D: 21412
```

Bench: 2111079