### PR TITLE
PVS SEE prune captures

### DIFF
--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -350,6 +350,10 @@ namespace search {
                         if (depth <= 6 && !see(board, move, -depth * 100)) {
                             continue;
                         }
+                    } else {
+                        if (depth <= 5 && !see(board, move, -depth * 150)) {
+                            continue;
+                        }
                     }
 
                     if (depth <= 5 && made_moves >= 5 + depth * depth / (2 - improving)) {


### PR DESCRIPTION
STC:
```
ELO   | 13.36 +- 7.48 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4320 W: 1209 L: 1043 D: 2068
```

LTC:
```
ELO   | 19.47 +- 9.09 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2680 W: 715 L: 565 D: 1400
```

Bench: 2371835