### PR TITLE
Adjust LMR based on butterfly history

### DIFF
--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -376,11 +376,12 @@ namespace search {
 
                     R -= pv_node;
                     R += !improving;
+                    R -= std::clamp(history.butterfly[move.get_from()][move.get_to()] / 8192, -2, 2);
 
                     Depth D = std::clamp(depth - R, 1, depth - 1);
                     score = -search<NON_PV_NODE>(D, -alpha - 1, -alpha, ss + 1);
 
-                    if (score > alpha && R > 0) {
+                    if (score > alpha && R > 1) {
                         score = -search<NON_PV_NODE>(depth - 1, -alpha - 1, -alpha, ss + 1);
                     }
                 } else if (non_pv_node || made_moves != 0) {


### PR DESCRIPTION
STC:
```
ELO   | 3.78 +- 3.05 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 25064 W: 6455 L: 6182 D: 12427
```

LTC:
```
ELO   | 16.43 +- 8.27 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3216 W: 839 L: 687 D: 1690
```

Bench: 2134743