### PR TITLE
Add best move effort to time management

### DIFF
--- a/src/search/time_manager.h
+++ b/src/search/time_manager.h
@@ -80,11 +80,11 @@ namespace search {
          * @param bm_stability The stability of the best move.
          * @return Returns if the search should continue.
          */
-        bool handle_iteration(int bm_stability) {
-
+        bool handle_iteration(int bm_stability, double bm_effort) {
             const double bm_scale = 1.2 - std::min(bm_stability, 10) * 0.04;
+            const double effort_scale = 1.5 - bm_effort;
 
-            double scale = bm_scale;
+            const double scale = bm_scale * effort_scale;
 
             update_end_time(scale);
 


### PR DESCRIPTION
STC:
```
ELO   | 4.38 +- 3.48 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 19296 W: 5009 L: 4766 D: 9521
```

LTC:
```
ELO   | 2.95 +- 2.31 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 40152 W: 9504 L: 9163 D: 21485
```

Bench: 2134743