### PR TITLE
Improve qsearch see speed

### DIFF
--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -494,7 +494,7 @@ namespace search {
 
                 if (alpha > -WORST_MATE && !see(board, move, 0)) {
                     stat_tracker::record_success("qsearch_see");
-                    continue;
+                    break;
                 } else {
                     stat_tracker::record_fail("qsearch_see");
                 }


### PR DESCRIPTION
STC:
```
ELO   | 2.35 +- 1.53 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 99344 W: 25184 L: 24511 D: 49649
```

Bench: 2071590