### PR TITLE
Tempo bonus

### DIFF
--- a/src/network/eval.h
+++ b/src/network/eval.h
@@ -35,6 +35,6 @@ namespace eval {
             }
         }
 
-        return nnue.evaluate(board.get_stm());
+        return nnue.evaluate(board.get_stm()) + 5 * (piece_count >= 7);
     }
 } // namespace eval


### PR DESCRIPTION
STC:
```
ELO   | 5.78 +- 4.32 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 12256 W: 3138 L: 2934 D: 6184
```

LTC:
```
ELO   | 4.69 +- 3.66 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 15856 W: 3745 L: 3531 D: 8580
```

Bench: 2023480