### PR TITLE
Bigger tempo bonus

### DIFF
--- a/src/network/eval.h
+++ b/src/network/eval.h
@@ -35,6 +35,6 @@ namespace eval {
             }
         }
 
-        return nnue.evaluate(board.get_stm()) + 5 * (piece_count >= 7);
+        return nnue.evaluate(board.get_stm()) + 20 * (piece_count >= 7);
     }
 } // namespace eval


### PR DESCRIPTION
STC:
```
ELO   | 5.31 +- 4.07 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13872 W: 3558 L: 3346 D: 6968
```

LTC:
```
ELO   | 8.14 +- 5.42 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7304 W: 1776 L: 1605 D: 3923
```

Bench: 1812902