### PR TITLE
8 Byte TT Entries

### DIFF
--- a/src/chess/constants.h
+++ b/src/chess/constants.h
@@ -38,13 +38,9 @@ using Ply = int8_t;
 
 constexpr int64_t INF_TIME = 1'000'000'000'000'000;
 constexpr int64_t INF_NODES = 1'000'000'000'000'000;
-constexpr Score UNKNOWN_SCORE = 300000;
-constexpr Score INF_SCORE = 200000;
-constexpr Score MATE_VALUE = 100000;
-constexpr Score TB_WIN_SCORE = 50000;
-constexpr Score TB_WORST_WIN = 49000;
-constexpr Score TB_BEST_LOSS = -49000;
-constexpr Score TB_LOSS_SCORE = -50000;
+constexpr Score UNKNOWN_SCORE = 30000;
+constexpr Score INF_SCORE = 20000;
+constexpr Score MATE_VALUE = 10000;
 constexpr Score WORST_MATE = MATE_VALUE - 100;
 
 constexpr Score PIECE_VALUES[7] = {

--- a/src/search/move_list.h
+++ b/src/search/move_list.h
@@ -25,13 +25,13 @@ namespace search {
     template<bool captures_only>
     class MoveList {
 
-        static constexpr unsigned int MOVE_SCORE_HASH = 10'000'000;
-        static constexpr unsigned int MOVE_SCORE_PROMO = 9'000'000;
-        static constexpr unsigned int MOVE_SCORE_GOOD_CAPTURE = 8'000'000;
-        static constexpr unsigned int MOVE_SCORE_FIRST_KILLER = 7'000'000;
-        static constexpr unsigned int MOVE_SCORE_SECOND_KILLER = 6'000'000;
-        static constexpr unsigned int MOVE_SCORE_COUNTER = 5'000'000;
-        static constexpr unsigned int MOVE_SCORE_BAD_CAPTURE = 4'000'000;
+        static constexpr int MOVE_SCORE_HASH = 10'000'000;
+        static constexpr int MOVE_SCORE_PROMO = 9'000'000;
+        static constexpr int MOVE_SCORE_GOOD_CAPTURE = 8'000'000;
+        static constexpr int MOVE_SCORE_FIRST_KILLER = 7'000'000;
+        static constexpr int MOVE_SCORE_SECOND_KILLER = 6'000'000;
+        static constexpr int MOVE_SCORE_COUNTER = 5'000'000;
+        static constexpr int MOVE_SCORE_BAD_CAPTURE = 4'000'000;
 
     public:
         /**
@@ -77,20 +77,20 @@ namespace search {
     private:
         chess::Move moves[200];
         unsigned int size, current;
-        Score scores[200];
+        int scores[200];
         const chess::Board &board;
         const chess::Move &hash_move;
         const chess::Move &last_move;
         const History &history;
         const Ply &ply;
 
-        [[nodiscard]] Score get_mvv_lva(const chess::Move &move) const {
+        [[nodiscard]] int get_mvv_lva(const chess::Move &move) const {
             return move.eq_flag(chess::Move::EP_CAPTURE)
                            ? MVVLVA[PAWN][PAWN]
                            : MVVLVA[board.piece_at(move.get_to()).type][board.piece_at(move.get_from()).type];
         }
 
-        [[nodiscard]] Score score_move(const chess::Move &move) const {
+        [[nodiscard]] int score_move(const chess::Move &move) const {
             if (move == hash_move) {
                 return MOVE_SCORE_HASH;
             } else if (move.is_promo()) {

--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -292,12 +292,12 @@ namespace search {
             }
 
             std::optional<TTEntry> entry = shared.tt.probe(board.get_hash());
-            TTFlag flag = TT_ALPHA;
+            TTFlag flag = TTFlag::ALPHA;
             Score tt_score = entry ? convert_tt_score<false>(entry->eval, ss->ply) : UNKNOWN_SCORE;
             chess::Move hash_move = entry ? entry->hash_move : chess::NULL_MOVE;
 
             if (entry && non_pv_node && entry->depth >= depth && board.get_move50() < 90 &&
-                (entry->flag == TT_EXACT || (entry->flag == TT_ALPHA && tt_score <= alpha) || (entry->flag == TT_BETA && tt_score >= beta))) {
+                (entry->flag == TTFlag::EXACT || (entry->flag == TTFlag::ALPHA && tt_score <= alpha) || (entry->flag == TTFlag::BETA && tt_score >= beta))) {
                 stat_tracker::record_success("tt_cutoff");
                 return tt_score;
             } else {
@@ -444,7 +444,7 @@ namespace search {
                         }
                     }
 
-                    shared.tt.save(board.get_hash(), depth, convert_tt_score<true>(beta, ss->ply), TT_BETA, move);
+                    shared.tt.save(board.get_hash(), depth, convert_tt_score<true>(beta, ss->ply), TTFlag::BETA, move);
                     return beta;
                 }
 
@@ -457,7 +457,7 @@ namespace search {
                     }
 
                     if (score > alpha) {
-                        flag = TT_EXACT;
+                        flag = TTFlag::EXACT;
                         alpha = score;
                     }
                 }

--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -292,12 +292,12 @@ namespace search {
             }
 
             std::optional<TTEntry> entry = shared.tt.probe(board.get_hash());
-            TTFlag flag = TTFlag::ALPHA;
+            TTFlag flag = TT_ALPHA;
             Score tt_score = entry ? convert_tt_score<false>(entry->eval, ss->ply) : UNKNOWN_SCORE;
             chess::Move hash_move = entry ? entry->hash_move : chess::NULL_MOVE;
 
             if (entry && non_pv_node && entry->depth >= depth && board.get_move50() < 90 &&
-                (entry->flag == TTFlag::EXACT || (entry->flag == TTFlag::ALPHA && tt_score <= alpha) || (entry->flag == TTFlag::BETA && tt_score >= beta))) {
+                (entry->flag == TT_EXACT || (entry->flag == TT_ALPHA && tt_score <= alpha) || (entry->flag == TT_BETA && tt_score >= beta))) {
                 stat_tracker::record_success("tt_cutoff");
                 return tt_score;
             } else {
@@ -444,7 +444,7 @@ namespace search {
                         }
                     }
 
-                    shared.tt.save(board.get_hash(), depth, convert_tt_score<true>(beta, ss->ply), TTFlag::BETA, move);
+                    shared.tt.save(board.get_hash(), depth, convert_tt_score<true>(beta, ss->ply), TT_BETA, move);
                     return beta;
                 }
 
@@ -457,7 +457,7 @@ namespace search {
                     }
 
                     if (score > alpha) {
-                        flag = TTFlag::EXACT;
+                        flag = TT_EXACT;
                         alpha = score;
                     }
                 }

--- a/src/search/transposition_table.h
+++ b/src/search/transposition_table.h
@@ -24,21 +24,21 @@
 #include <cstring>
 
 namespace search {
-    enum class TTFlag : uint8_t {
-        NONE = 0,
-        EXACT = 1,
+    enum TTFlag : uint8_t {
+        TT_NONE = 0,
+        TT_EXACT = 1,
         // UPPERBOUND
-        ALPHA = 2,
+        TT_ALPHA = 2,
         // LOWERBOUND
-        BETA = 3
+        TT_BETA = 3
     };
 
-    struct TTEntry {                              // Total: 16 bytes
+    struct TTEntry {                              // Total: 8 bytes
         uint16_t hash = 0;                        // 2 bytes
         int16_t eval = 0;                         // 2 bytes
         chess::Move hash_move = chess::NULL_MOVE; // 2 bytes
         Depth depth = 0;                          // 1 byte
-        TTFlag flag = TTFlag::NONE;               // 1 byte
+        TTFlag flag = TT_NONE;                    // 1 byte
 
         constexpr TTEntry() = default;
     };
@@ -108,7 +108,7 @@ namespace search {
             TTEntry *entry = get_entry(hash64);
             auto hash16 = static_cast<uint16_t>(hash64 >> 48);
 
-            if (flag == TTFlag::ALPHA && entry->hash == hash16) {
+            if (flag == TT_ALPHA && entry->hash == hash16) {
                 best_move = chess::NULL_MOVE;
             }
 
@@ -116,7 +116,7 @@ namespace search {
                 entry->hash_move = best_move;
             }
 
-            if (entry->hash != hash16 || flag == TTFlag::EXACT || entry->depth <= depth + 4) {
+            if (entry->hash != hash16 || flag == TT_EXACT || entry->depth <= depth + 4) {
                 entry->hash = hash16;
                 entry->depth = depth;
                 entry->eval = static_cast<int16_t>(eval);
@@ -126,13 +126,6 @@ namespace search {
 
         void prefetch(uint64_t hash) {
             __builtin_prefetch(get_entry(hash), 0);
-        }
-
-        chess::Move get_hash_move(uint64_t hash) {
-            TTEntry *entry = get_entry(hash);
-            if (entry->hash == hash)
-                return entry->hash_move;
-            return chess::NULL_MOVE;
         }
 
     private:


### PR DESCRIPTION
STC:
```
ELO   | 5.46 +- 4.11 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 12800 W: 3087 L: 2886 D: 6827
```

LTC Simplification:
```
ELO   | 1.53 +- 3.79 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 14072 W: 3111 L: 3049 D: 7912
```

Bench: 12004127