### PR TITLE
Scaling NNUE eval based on material value

### DIFF
--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -84,6 +84,10 @@ namespace chess {
             return bb_pieces[pt];
         }
 
+        [[nodiscard]] constexpr Bitboard pieces(PieceType pt) const {
+            return bb_pieces[pt];
+        }
+
         template<Color color>
         [[nodiscard]] constexpr Bitboard sides() const {
             return bb_colors[color];

--- a/src/network/eval.h
+++ b/src/network/eval.h
@@ -21,6 +21,14 @@
 
 namespace eval {
 
+    Score get_material_scale(const chess::Board &board) {
+        Score material_value = 0;
+        for (const PieceType pt : PIECE_TYPES_BY_VALUE) {
+            material_value += PIECE_VALUES[pt] * board.pieces(pt).pop_count();
+        }
+        return 700 + material_value / 32;
+    }
+
     Score evaluate(const chess::Board &board, nn::NNUE &nnue) {
         const int piece_count = board.occupied().pop_count();
 
@@ -35,6 +43,9 @@ namespace eval {
             }
         }
 
-        return nnue.evaluate(board.get_stm());
+        Score nnue_eval = nnue.evaluate(board.get_stm());
+        Score scaled_eval = (nnue_eval * get_material_scale(board)) / 1024;
+
+        return scaled_eval;
     }
 } // namespace eval


### PR DESCRIPTION
STC:
```
ELO   | 3.08 +- 2.44 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 35888 W: 8438 L: 8120 D: 19330
```

LTC:
```
ELO   | 16.15 +- 7.98 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3144 W: 752 L: 606 D: 1786
```

Bench: 11066285