### PR TITLE
Tweak LMR history extensions

### DIFF
--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -406,7 +406,7 @@ namespace search {
 
                     R -= pv_node;
                     R += !improving;
-                    R -= std::clamp(history.butterfly[move.get_from()][move.get_to()] / 8192, -2, 2);
+                    R -= std::clamp(history.butterfly[move.get_from()][move.get_to()] / 4096, -2, 2);
 
                     Depth D = std::clamp(new_depth - R, 1, depth - 1);
                     score = -search<NON_PV_NODE>(D, -alpha - 1, -alpha, ss + 1);


### PR DESCRIPTION
STC:
```
ELO   | 5.73 +- 4.25 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 11584 W: 2717 L: 2526 D: 6341
```

LTC:
```
ELO   | 8.04 +- 5.30 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7216 W: 1662 L: 1495 D: 4059
```

Bench: 12530622