### PR TITLE
Keep thread data when possible

### DIFF
--- a/src/search/history.h
+++ b/src/search/history.h
@@ -61,6 +61,7 @@ namespace search {
             for (int i = 0; i < 64; i++) {
                 for (int j = 0; j < 64; j++) {
                     butterfly[i][j] = 0;
+                    counter_moves[i][j] = chess::NULL_MOVE;
                 }
             }
         }


### PR DESCRIPTION
STC Simplification:
```
ELO   | -0.41 +- 1.74 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 70992 W: 16388 L: 16472 D: 38132
```

Passed STC SMP:
```
ELO   | 2.77 +- 2.13 (95%)
SPRT  | 5.0+0.05s Threads=3 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 48266 W: 11574 L: 11189 D: 25503
```

Bench: 12530622