### PR TITLE
50mr eval scaling

### DIFF
--- a/src/network/eval.h
+++ b/src/network/eval.h
@@ -26,7 +26,7 @@ namespace eval {
         for (const PieceType pt : PIECE_TYPES_BY_VALUE) {
             material_value += PIECE_VALUES[pt] * board.pieces(pt).pop_count();
         }
-        return 700 + material_value / 32 - static_cast<int>(board.get_move50()) * 10;
+        return 700 + material_value / 32 - static_cast<int>(board.get_move50()) * 5;
     }
 
     Score evaluate(const chess::Board &board, nn::NNUE &nnue) {

--- a/src/network/eval.h
+++ b/src/network/eval.h
@@ -21,12 +21,12 @@
 
 namespace eval {
 
-    Score get_material_scale(const chess::Board &board) {
+    Score get_eval_scale(const chess::Board &board) {
         Score material_value = 0;
         for (const PieceType pt : PIECE_TYPES_BY_VALUE) {
             material_value += PIECE_VALUES[pt] * board.pieces(pt).pop_count();
         }
-        return 700 + material_value / 32;
+        return 700 + material_value / 32 - static_cast<int>(board.get_move50()) * 20;
     }
 
     Score evaluate(const chess::Board &board, nn::NNUE &nnue) {
@@ -44,7 +44,7 @@ namespace eval {
         }
 
         Score nnue_eval = nnue.evaluate(board.get_stm());
-        Score scaled_eval = (nnue_eval * get_material_scale(board)) / 1024;
+        Score scaled_eval = (nnue_eval * get_eval_scale(board)) / 1024;
 
         return scaled_eval;
     }

--- a/src/network/eval.h
+++ b/src/network/eval.h
@@ -26,7 +26,7 @@ namespace eval {
         for (const PieceType pt : PIECE_TYPES_BY_VALUE) {
             material_value += PIECE_VALUES[pt] * board.pieces(pt).pop_count();
         }
-        return 700 + material_value / 32 - static_cast<int>(board.get_move50()) * 20;
+        return 700 + material_value / 32 - static_cast<int>(board.get_move50()) * 10;
     }
 
     Score evaluate(const chess::Board &board, nn::NNUE &nnue) {


### PR DESCRIPTION
Neutral at STC:
```
ELO   | 0.63 +- 2.31 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | -2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 40616 W: 9522 L: 9448 D: 21646
```
Passed LTC:
```
ELO   | 2.57 +- 1.95 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 53712 W: 12038 L: 11641 D: 30033
```

Bench: 12990924