### PR TITLE
Tweak LMR move index formula

### DIFF
--- a/src/search/search_thread.h
+++ b/src/search/search_thread.h
@@ -401,7 +401,7 @@ namespace search {
                 board.make_move(move, &nnue);
                 Score score;
 
-                if (!in_check && depth >= 3 && made_moves >= 4 && !move.is_promo() && move.is_quiet()) {
+                if (!in_check && depth >= 3 && made_moves >= 3 + 2 * pv_node && !move.is_promo() && move.is_quiet()) {
                     Depth R = lmr_reductions[depth][made_moves];
 
                     R -= pv_node;


### PR DESCRIPTION
STC:
```
ELO   | 3.56 +- 2.87 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 27104 W: 6693 L: 6415 D: 13996
```

LTC:
```
ELO   | 3.32 +- 2.67 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 28992 W: 6638 L: 6361 D: 15993
```

Bench: 9812163