### PR TITLE
Good and bad promos

### DIFF
--- a/src/search/move_list.h
+++ b/src/search/move_list.h
@@ -26,7 +26,8 @@ namespace search {
     class MoveList {
 
         static constexpr int MOVE_SCORE_HASH = 10'000'000;
-        static constexpr int MOVE_SCORE_PROMO = 9'000'000;
+        static constexpr int MOVE_SCORE_GOOD_PROMO = 9'000'000;
+        static constexpr int MOVE_SCORE_BAD_PROMO = -10'000'000;
         static constexpr int MOVE_SCORE_GOOD_CAPTURE = 8'000'000;
         static constexpr int MOVE_SCORE_FIRST_KILLER = 7'000'000;
         static constexpr int MOVE_SCORE_SECOND_KILLER = 6'000'000;
@@ -95,7 +96,7 @@ namespace search {
             if (move == hash_move) {
                 return MOVE_SCORE_HASH;
             } else if (move.is_promo()) {
-                return MOVE_SCORE_PROMO;
+                return move.get_promo_type() == QUEEN ? MOVE_SCORE_GOOD_PROMO : MOVE_SCORE_BAD_PROMO;
             } else if (move.is_capture()) {
                 return (see(board, move, 0) ? MOVE_SCORE_GOOD_CAPTURE : MOVE_SCORE_BAD_CAPTURE) + get_mvv_lva(move);
             } else if (move == history.killer_moves[ply][0]) {


### PR DESCRIPTION
STC:
```
ELO   | 4.01 +- 3.20 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 21504 W: 5229 L: 4981 D: 11294
```
LTC:
```
ELO   | 4.87 +- 3.75 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 14616 W: 3357 L: 3152 D: 8107
```

Bench: 9303499